### PR TITLE
Qualify Macro Inputs

### DIFF
--- a/examples/multi-token/mt/src/lib.rs
+++ b/examples/multi-token/mt/src/lib.rs
@@ -13,127 +13,134 @@ NOTES:
   - To prevent the deployed contract from being modified or deleted, it should not have any access
     keys on its account.
 */
+use multi_token_standard::metadata::MultiTokenMetadata;
+use multi_token_standard::MultiToken;
+use multi_token_standard::{TokenId, TokenType};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LazyOption, LookupMap};
 use near_sdk::json_types::U128;
-use near_sdk::{env, log, near_bindgen, AccountId, Balance, BorshStorageKey, PanicOnDefault, PromiseOrValue, require, Promise};
-use multi_token_standard::MultiToken;
-use multi_token_standard::metadata::MultiTokenMetadata;
+use near_sdk::{
+    env, log, near_bindgen, require, AccountId, Balance, BorshStorageKey, PanicOnDefault, Promise,
+    PromiseOrValue,
+};
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
 pub struct Contract {
-  token: MultiToken,
+    token: MultiToken,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, BorshStorageKey)]
 enum StorageKey {
-  MultiTokenOwner,
-  MultiTokenMetadata,
-  MultiTokenSupply,
+    MultiTokenOwner,
+    MultiTokenMetadata,
+    MultiTokenSupply,
 }
 
 #[near_bindgen]
 impl Contract {
-  #[init]
-  pub fn new(owner_id: AccountId) -> Self {
-    assert!(!env::state_exists(), "Already initialized");
-    Self {
-      token: MultiToken::new(
-        StorageKey::MultiTokenOwner,
-        owner_id,
-        Some(StorageKey::MultiTokenMetadata),
-        StorageKey::MultiTokenSupply,
-      ),
+    #[init]
+    pub fn new(owner_id: AccountId) -> Self {
+        assert!(!env::state_exists(), "Already initialized");
+        Self {
+            token: MultiToken::new(
+                StorageKey::MultiTokenOwner,
+                owner_id,
+                Some(StorageKey::MultiTokenMetadata),
+                StorageKey::MultiTokenSupply,
+            ),
+        }
     }
-  }
 
-  fn refund_deposit(&self, storage_used: u64) {
-    let required_cost = env::storage_byte_cost() * Balance::from(storage_used);
-    let attached_deposit = env::attached_deposit();
-    assert!(
-      required_cost <= attached_deposit,
-      "Must attach {} yoctoNEAR to cover storage",
-      required_cost,
-    );
-    let refund = attached_deposit - required_cost;
-    if refund > 1 {
-      Promise::new(env::predecessor_account_id()).transfer(refund);
+    fn refund_deposit(&self, storage_used: u64) {
+        let required_cost = env::storage_byte_cost() * Balance::from(storage_used);
+        let attached_deposit = env::attached_deposit();
+        assert!(
+            required_cost <= attached_deposit,
+            "Must attach {} yoctoNEAR to cover storage",
+            required_cost,
+        );
+        let refund = attached_deposit - required_cost;
+        if refund > 1 {
+            Promise::new(env::predecessor_account_id()).transfer(refund);
+        }
     }
-  }
 
-  #[payable]
-  pub fn mint(
-      &mut self,
-      token_id: TokenId,
-      token_type: TokenType,
-      amount: Option<U128>,
-      token_owner_id: AccountId,
-      token_metadata: Option<MultiTokenMetadata>,
+    #[payable]
+    pub fn mint(
+        &mut self,
+        token_id: TokenId,
+        token_type: TokenType,
+        amount: Option<U128>,
+        token_owner_id: AccountId,
+        token_metadata: Option<MultiTokenMetadata>,
     ) {
-      let initial_storage_usage = env::storage_usage();
-      require!(env::predecessor_account_id() == self.token.owner_id, "Unauthorized");
-      if self.token.token_metadata_by_id.is_some() && token_metadata.is_none() {
-        env::panic_str("Must provide metadata");
-      }
+        let initial_storage_usage = env::storage_usage();
+        require!(env::predecessor_account_id() == self.token.owner_id, "Unauthorized");
+        if self.token.token_metadata_by_id.is_some() && token_metadata.is_none() {
+            env::panic_str("Must provide metadata");
+        }
 
-      // Every token must have a token type and every NFT type cannot be re-minted
-      match self.token.token_type_index.get(&token_id) {
-        Some(TokenType::Ft) => {
-         require!(token_type == TokenType::Ft, "Type must be of FT time tokenId already exists")
-        }
-        Some(TokenType::Nft) => {
-          env::panic_str("Attempting to mint already minted NFT");
-        }
-        None => {
-          self.token.token_type_index.insert(&token_id, &token_type);
-        }
-      }
-
-      let owner_id: AccountId = token_owner_id;
-      // Core behavior: every token must have an owner
-      match token_type {
-        TokenType::Ft => {
-          if amount.is_none() {
-            env::panic_str("Amount must be specified for Ft type tokens");
-          }
-          // advance the prefix index before insertion
-          let amt = u128::from(amount.unwrap());
-          //create LookupMap for balances
-          match self.token.ft_owners_by_id.get(&token_id) {
-            Some(mut balances) => {
-              let current_bal = balances.get(&owner_id).unwrap_or(0);
-              // TODO not quite safe
-              if amt == 0 {
-                env::panic_str("error: amount should be greater than 0")
-              }
-              balances.insert(&owner_id, &(current_bal + amt));
-              let supply = self.token.ft_token_supply_by_id.get(&token_id).unwrap();
-              self.token.ft_token_supply_by_id.insert(&token_id, &(supply + amt));
+        // Every token must have a token type and every NFT type cannot be re-minted
+        match self.token.token_type_index.get(&token_id) {
+            Some(TokenType::Ft) => {
+                require!(
+                    token_type == TokenType::Ft,
+                    "Type must be of FT time tokenId already exists"
+                )
+            }
+            Some(TokenType::Nft) => {
+                env::panic_str("Attempting to mint already minted NFT");
             }
             None => {
-              let mut balances = self.token.internal_new_ft_balances();
-              // insert amount into balances
-              balances.insert(&owner_id, &amt);
-              self.token.ft_owners_by_id.insert(&token_id, &balances);
-              self.token.ft_token_supply_by_id.insert(&token_id, &amt);
+                self.token.token_type_index.insert(&token_id, &token_type);
             }
-          }
         }
-        TokenType::Nft => {
-          self.token.nft_owner_by_id.insert(&token_id, &owner_id);
+
+        let owner_id: AccountId = token_owner_id;
+        // Core behavior: every token must have an owner
+        match token_type {
+            TokenType::Ft => {
+                if amount.is_none() {
+                    env::panic_str("Amount must be specified for Ft type tokens");
+                }
+                // advance the prefix index before insertion
+                let amt = u128::from(amount.unwrap());
+                //create LookupMap for balances
+                match self.token.ft_owners_by_id.get(&token_id) {
+                    Some(mut balances) => {
+                        let current_bal = balances.get(&owner_id).unwrap_or(0);
+                        // TODO not quite safe
+                        if amt == 0 {
+                            env::panic_str("error: amount should be greater than 0")
+                        }
+                        balances.insert(&owner_id, &(current_bal + amt));
+                        let supply = self.token.ft_token_supply_by_id.get(&token_id).unwrap();
+                        self.token.ft_token_supply_by_id.insert(&token_id, &(supply + amt));
+                    }
+                    None => {
+                        let mut balances = self.token.internal_new_ft_balances();
+                        // insert amount into balances
+                        balances.insert(&owner_id, &amt);
+                        self.token.ft_owners_by_id.insert(&token_id, &balances);
+                        self.token.ft_token_supply_by_id.insert(&token_id, &amt);
+                    }
+                }
+            }
+            TokenType::Nft => {
+                self.token.nft_owner_by_id.insert(&token_id, &owner_id);
+            }
         }
-      }
-      // Metadata extension: Save metadata, keep variable around to return later.
-      // Note that check above already panicked if metadata extension in use but no metadata
-      // provided to call.
-      self.token
-          .token_metadata_by_id
-          .as_mut()
-          .and_then(|by_id| by_id.insert(&token_id, &token_metadata.as_ref().unwrap()));
-      // Return any extra attached deposit not used for storage
-      self.refund_deposit(env::storage_usage() - initial_storage_usage);
-  }
+        // Metadata extension: Save metadata, keep variable around to return later.
+        // Note that check above already panicked if metadata extension in use but no metadata
+        // provided to call.
+        self.token
+            .token_metadata_by_id
+            .as_mut()
+            .and_then(|by_id| by_id.insert(&token_id, &token_metadata.as_ref().unwrap()));
+        // Return any extra attached deposit not used for storage
+        self.refund_deposit(env::storage_usage() - initial_storage_usage);
+    }
 }
 multi_token_standard::impl_multi_token_core!(Contract, token);
 multi_token_standard::impl_multi_token_storage!(Contract, token);

--- a/multi_token/src/macros.rs
+++ b/multi_token/src/macros.rs
@@ -5,18 +5,14 @@
 #[macro_export]
 macro_rules! impl_multi_token_core {
     ($contract: ident, $token: ident) => {
-        use $crate::core::MultiTokenCore;
-        use $crate::core::MultiTokenResolver;
-        use $crate::{TokenId, TokenType};
-
         #[near_bindgen]
-        impl MultiTokenCore for $contract {
+        impl $crate::core::MultiTokenCore for $contract {
             #[payable]
             fn mt_transfer(
                 &mut self,
-                receiver_id: AccountId,
-                token_id: TokenId,
-                amount: U128,
+                receiver_id: near_sdk::AccountId,
+                token_id: $crate::TokenId,
+                amount: near_sdk::json_types::U128,
                 memo: Option<String>,
             ) {
                 self.$token.mt_transfer(receiver_id, token_id, amount, memo)
@@ -25,9 +21,9 @@ macro_rules! impl_multi_token_core {
             #[payable]
             fn mt_transfer_call(
                 &mut self,
-                receiver_id: AccountId,
-                token_id: TokenId,
-                amount: U128,
+                receiver_id: near_sdk::AccountId,
+                token_id: $crate::TokenId,
+                amount: near_sdk::json_types::U128,
                 memo: Option<String>,
                 msg: String,
             ) -> PromiseOrValue<U128> {
@@ -37,8 +33,8 @@ macro_rules! impl_multi_token_core {
             #[payable]
             fn mt_batch_transfer(
                 &mut self,
-                receiver_id: AccountId,
-                token_id: Vec<TokenId>,
+                receiver_id: near_sdk::AccountId,
+                token_id: Vec<$crate::TokenId>,
                 amounts: Vec<U128>,
                 memo: Option<String>,
             ) {
@@ -48,8 +44,8 @@ macro_rules! impl_multi_token_core {
             #[payable]
             fn mt_batch_transfer_call(
                 &mut self,
-                receiver_id: AccountId,
-                token_ids: Vec<TokenId>,
+                receiver_id: near_sdk::AccountId,
+                token_ids: Vec<$crate::TokenId>,
                 amounts: Vec<U128>,
                 memo: Option<String>,
                 msg: String,
@@ -57,31 +53,39 @@ macro_rules! impl_multi_token_core {
                 self.$token.mt_batch_transfer_call(receiver_id, token_ids, amounts, memo, msg)
             }
 
-            fn balance_of(&self, owner_id: AccountId, token_id: TokenId) -> U128 {
+            fn balance_of(
+                &self,
+                owner_id: near_sdk::AccountId,
+                token_id: $crate::TokenId,
+            ) -> near_sdk::json_types::U128 {
                 self.$token.balance_of(owner_id, token_id)
             }
 
-            fn balance_of_batch(&self, owner_id: AccountId, token_ids: Vec<TokenId>) -> Vec<U128> {
+            fn balance_of_batch(
+                &self,
+                owner_id: near_sdk::AccountId,
+                token_ids: Vec<$crate::TokenId>,
+            ) -> Vec<U128> {
                 self.$token.balance_of_batch(owner_id, token_ids)
             }
 
-            fn total_supply(&self, token_id: TokenId) -> U128 {
+            fn total_supply(&self, token_id: $crate::TokenId) -> near_sdk::json_types::U128 {
                 self.$token.total_supply(token_id)
             }
 
-            fn total_supply_batch(&self, token_ids: Vec<TokenId>) -> Vec<U128> {
+            fn total_supply_batch(&self, token_ids: Vec<$crate::TokenId>) -> Vec<U128> {
                 self.$token.total_supply_batch(token_ids)
             }
         }
 
         #[near_bindgen]
-        impl MultiTokenResolver for $contract {
+        impl $crate::core::MultiTokenResolver for $contract {
             #[private]
             fn mt_resolve_transfer(
                 &mut self,
-                sender_id: AccountId,
-                receiver_id: AccountId,
-                token_ids: Vec<TokenId>,
+                sender_id: near_sdk::AccountId,
+                receiver_id: near_sdk::AccountId,
+                token_ids: Vec<$crate::TokenId>,
                 amounts: Vec<U128>,
             ) -> Vec<U128> {
                 self.$token.mt_resolve_transfer(sender_id, receiver_id, token_ids, amounts)
@@ -107,19 +111,19 @@ macro_rules! impl_multi_token_storage {
             #[payable]
             fn storage_deposit(
                 &mut self,
-                token_ids: Vec<TokenId>,
-                account_id: Option<AccountId>,
+                token_ids: Vec<$crate::TokenId>,
+                account_id: Option<near_sdk::AccountId>,
                 registration_only: Option<bool>,
             ) -> StorageBalance {
                 self.$token.storage_deposit(token_ids, account_id, registration_only)
             }
             #[payable]
-            fn storage_withdraw(&mut self, token_ids:Vec<TokenId>, amount: Option<U128>) -> StorageBalance {
+            fn storage_withdraw(&mut self, token_ids:Vec<$crate::TokenId>, amount: Option<U128>) -> StorageBalance {
                 self.$token.storage_withdraw(token_ids, amount)
             }
 
             #[payable]
-            fn storage_unregister(&mut self, token_ids: Vec<TokenId>, force: Option<bool>) -> Vec<bool> {
+            fn storage_unregister(&mut self, token_ids: Vec<$crate::TokenId>, force: Option<bool>) -> Vec<bool> {
                #[allow(unused_variables)]
                let final_states = self.$token.internal_storage_unregister_batch(token_ids, force);
                 final_states.iter().map(|final_state|{
@@ -132,11 +136,11 @@ macro_rules! impl_multi_token_storage {
                     }).collect()
             }
 
-            fn storage_balance_bounds(&self, token_ids: Vec<TokenId>, account_id: Option<AccountId>) -> StorageBalanceBounds {
+            fn storage_balance_bounds(&self, token_ids: Vec<$crate::TokenId>, account_id: Option<AccountId>) -> StorageBalanceBounds {
                 self.$token.internal_storage_balance_bounds_batch(&token_ids, account_id)
             }
 
-            fn storage_balance_of(&self, token_ids: Vec<TokenId>, account_id: AccountId) -> Option<StorageBalance> {
+            fn storage_balance_of(&self, token_ids: Vec<$crate::TokenId>, account_id: near_sdk::AccountId) -> Option<StorageBalance> {
                 self.$token.internal_storage_balance_of_batch(&token_ids, &account_id)
             }
         }

--- a/multi_token/src/macros.rs
+++ b/multi_token/src/macros.rs
@@ -5,8 +5,11 @@
 #[macro_export]
 macro_rules! impl_multi_token_core {
     ($contract: ident, $token: ident) => {
+        use $crate::core::MultiTokenCore;
+        use $crate::core::MultiTokenResolver;
+
         #[near_bindgen]
-        impl $crate::core::MultiTokenCore for $contract {
+        impl MultiTokenCore for $contract {
             #[payable]
             fn mt_transfer(
                 &mut self,


### PR DESCRIPTION
- Qualify Macro inputs

The reasoning behind this:
I was using the multi token impl macro, but defined my own `TokenId` type. In general, I think it would just be safer and cleaner to qualify macro imports